### PR TITLE
Add GenerationOptions struct

### DIFF
--- a/src/llm_integration.rs
+++ b/src/llm_integration.rs
@@ -45,6 +45,17 @@ pub struct ModelInfo {
     pub metadata: serde_json::Value,
 }
 
+/// Generation options for LLMs
+#[derive(Debug, Clone, Default)]
+pub struct GenerationOptions {
+    pub temperature: Option<f32>,
+    pub top_k: Option<i32>,
+    pub top_p: Option<f32>,
+    pub repeat_penalty: Option<f32>,
+    pub context_length: Option<usize>,
+    pub mirostat: Option<i32>,
+}
+
 /// Create an LLM model based on the specified backend
 pub fn create_llm_model(model_path: &Path, backend: LlmBackend) -> Result<Box<dyn LlmModel>> {
     match backend {


### PR DESCRIPTION
## Summary
- add a GenerationOptions struct to support common generation settings

## Testing
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_68b7e1b7fc008327a5795d521fe721f8